### PR TITLE
Access private and protected properties and methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,16 +151,6 @@ $dot = new Dot($class);
 echo $dot->get('iDoSomething'); // I Do Something 0
 ```
 
-### It's not possible to access private or protected properties
-```php
-$class = new class() {
-    private string $property = 'test';
-}
-
-$dot = new Dot($class);
-echo $dot->get('property'); //Unhandled Exception: WebFu\DotNotation\Exception\PathNotFoundException Path `property` not found
-```
-
 ### It's not possible to discern if a method returns NULL or does not return at all
 ```php
 $class = new class() {

--- a/src/Proxy/ClassProxy.php
+++ b/src/Proxy/ClassProxy.php
@@ -77,7 +77,13 @@ class ClassProxy implements ProxyInterface
         if (str_ends_with($key, '()')) {
             $method = str_replace('()', '', $key);
 
-            return $this->element->{$method}();
+            return Closure::bind(
+                static function (object $element) use ($method) {
+                    return $element->{$method}();
+                },
+                null,
+                $this->element,
+            )($this->element);
         }
 
         if ($this->element instanceof stdClass) {

--- a/tests/DotTest.php
+++ b/tests/DotTest.php
@@ -169,9 +169,6 @@ class DotTest extends TestCase
         yield 'not_exits' => [
             'path' => 'notExists',
         ];
-        yield 'private' => [
-            'path' => 'private',
-        ];
     }
 
     /**

--- a/tests/Proxy/ClassProxyTest.php
+++ b/tests/Proxy/ClassProxyTest.php
@@ -42,11 +42,23 @@ class ClassProxyTest extends TestCase
 
         $this->assertEquals([
             'public',
+            'protected',
+            'private',
             'publicParent',
+            'protectedParent',
             'publicTrait',
+            'protectedTrait',
+            'privateTrait',
             'public()',
+            'protected()',
+            'private()',
             'publicParent()',
+            'protectedParent()',
             'publicTrait()',
+            'protectedTrait()',
+            'privateTrait()',
+            'privateParent',
+            'privateParent()',
         ], $proxy->getKeys());
     }
 
@@ -87,7 +99,7 @@ class ClassProxyTest extends TestCase
                 private string $property;
             },
             'key'      => 'property',
-            'expected' => false,
+            'expected' => true,
         ];
         yield 'class.method.exists' => [
             'element' => new class {
@@ -114,7 +126,7 @@ class ClassProxyTest extends TestCase
                 }
             },
             'key'      => 'method()',
-            'expected' => false,
+            'expected' => true,
         ];
     }
 
@@ -128,11 +140,23 @@ class ClassProxyTest extends TestCase
 
         $this->assertSame([
             'public',
+            'protected',
+            'private',
             'publicParent',
+            'protectedParent',
             'publicTrait',
+            'protectedTrait',
+            'privateTrait',
             'public()',
+            'protected()',
+            'private()',
             'publicParent()',
+            'protectedParent()',
             'publicTrait()',
+            'protectedTrait()',
+            'privateTrait()',
+            'privateParent',
+            'privateParent()',
         ], $proxy->getKeys());
     }
 
@@ -189,7 +213,7 @@ class ClassProxyTest extends TestCase
     /**
      * @covers ::get
      */
-    public function testGetFailsIfKeyIsPrivate(): void
+    public function testGetPrivateProperty(): void
     {
         $element = new class {
             /**
@@ -198,11 +222,26 @@ class ClassProxyTest extends TestCase
             private string $property = 'foo';
         };
 
-        $this->expectException(PathNotFoundException::class);
-        $this->expectExceptionMessage('Key `property` not found');
+        $proxy = new ClassProxy($element);
+
+        self::assertSame('foo', $proxy->get('property'));
+    }
+
+    /**
+     * @covers ::get
+     */
+    public function testGetProtectedProperty(): void
+    {
+        $element = new class {
+            /**
+             * @phpstan-ignore-next-line
+             */
+            protected string $property = 'foo';
+        };
 
         $proxy = new ClassProxy($element);
-        $proxy->get('property');
+
+        self::assertSame('foo', $proxy->get('property'));
     }
 
     /**


### PR DESCRIPTION
This pull request includes significant changes to the `ClassProxy` class and `ClassProxyTest` class to support the handling of private and protected properties and methods.

* `src/Proxy/ClassProxy.php`: Added `ReflectionClass` as a private member and updated the constructor to initialize it. Introduced new methods `getMethod` and `getProperty` to handle access to methods and properties, including private and protected ones. Updated the `get` method to use these new methods.

* `tests/Proxy/ClassProxyTest.php`: Updated various tests to include checks for private and protected properties and methods. This includes updates to `testConstruct`, `hasDataProvider`, `testGetKeys`, and new tests `testGetPrivateProperty` and `testGetProtectedProperty`. 

* `README.md` : Removed the section explaining that private or protected properties cannot be accessed, as this is no longer accurate with the new changes.

* `tests/DotTest.php`: Removed the test case for private property access from `invalidPathProvider` as it is now supported.